### PR TITLE
add vim-mode:open-link

### DIFF
--- a/src/vim.js
+++ b/src/vim.js
@@ -901,7 +901,19 @@ class Plugin {
         motion: 'moveToOtherHighlightedEnd',
         motionArgs: { sameLine: true },
         context: 'visual'
-      })
+      }),
+      'vim-mode:open-link': () => {
+         const cur = cm.getCursor()
+         const token = cm.getTokenAt(cur)
+         if (token.type == 'url') {
+           open(token.string)
+         } else if (token.type = "string url") {
+            const link = token.string.replace("inkdrop://", "")
+            inkdrop.commands.dispatch(document.body, "core:open-note", {
+              noteId: link,
+            })
+         }
+      }
     }
     disposables.add(inkdrop.commands.add(wrapper, handlers))
     wrapper.addEventListener('textInput', this.handleEditorTextInput)


### PR DESCRIPTION
hi.

I want to open link without mouse.
So, I added `vim-mode:open-link'.
It open link with browser or jump to note.

I define key like this. This is so useful.

```
'.CodeMirror.vim-mode:not(.insert-mode):not(.key-buffering) textarea':
    'enter': 'vim-mode:open-link'
```

I tested Windows and Mac.
What do you think of this?