### PR TITLE
Add clearSerchHighlight to vimApi

### DIFF
--- a/lib/keymap.js
+++ b/lib/keymap.js
@@ -1945,6 +1945,7 @@ module.exports = function (CodeMirror) {
       exitVisualMode: exitVisualMode,
       exitInsertMode: exitInsertMode,
       clearInputState: clearInputState,
+      clearSearchHighlight: clearSearchHighlight,
       cmKeyToVimKey: cmKeyToVimKey
     }; // Represents the current input state.
 

--- a/src/keymap.js
+++ b/src/keymap.js
@@ -863,6 +863,7 @@ module.exports = function (CodeMirror) {
       exitVisualMode: exitVisualMode,
       exitInsertMode: exitInsertMode,
       clearInputState: clearInputState,
+      clearSearchHighlight: clearSearchHighlight,
 
       cmKeyToVimKey: cmKeyToVimKey
     }


### PR DESCRIPTION
hi. 

inkdrop is so nice! and vim plugin so nice!

I want to clear search highlight by escape key in normal mode.
So, I create PR to access vimApi from init.js .

If this PR is merged, I define my command in init.js and keymap.cson .

```js
inkdrop.commands.add(document.body, "mycmd:reset-normal-mode", () => {
  inkdrop.commands.dispatch(document.body, "vim:reset-normal-mode");
  const cm = inkdrop.getActiveEditor().cm;
  const vim = inkdrop.packages.activePackages.vim.mainModule.vim;
  vim.clearSearchHighlight(cm);
});
```

```
'.CodeMirror.vim-mode.normal-mode textarea':
   'escape': 'mycmd:reset-normal-mode'
```

Or is there another good way?

thanks!