### PR TITLE
Not a number when a modifier key is pressed

### DIFF
--- a/lib/vim.js
+++ b/lib/vim.js
@@ -91,7 +91,7 @@ class Plugin {
       const keyName = normalizeKeyName(event.key);
       const cm = this.getCodeMirror();
       const vim = this.vim.maybeInitVimState(cm);
-      const isNumberic = keyName.match(/^\d$/);
+      const isNumberic = !event.ctrlKey && !event.altKey && !event.metaKey && !event.shiftKey && keyName.match(/^\d$/);
 
       if (this.isBufferingKey()) {
         _inkdrop.logger.debug('handle key buffering:', keyName, event);

--- a/src/vim.js
+++ b/src/vim.js
@@ -1045,7 +1045,12 @@ class Plugin {
     const keyName = normalizeKeyName(event.key)
     const cm = this.getCodeMirror()
     const vim = this.vim.maybeInitVimState(cm)
-    const isNumberic = keyName.match(/^\d$/)
+    const isNumberic =
+      !event.ctrlKey &&
+      !event.altKey &&
+      !event.metaKey &&
+      !event.shiftKey &&
+      keyName.match(/^\d$/);
 
     if (this.isBufferingKey()) {
       logger.debug('handle key buffering:', keyName, event)


### PR DESCRIPTION
Ctrl + 2, Ctrl+3  を 2 カラム表示とプレビュー表示のショートカットキーに当てています。
Ctrl を押していても回数指定と判定されていて j  でキー移動した場合に意図しない距離を移動してしまいます。 (2j or 3j の扱いになる)

修飾キーを押している場合は回数指定と判断しないように修正しました。